### PR TITLE
Fix problem with renderOpts

### DIFF
--- a/js2asr.js
+++ b/js2asr.js
@@ -10,9 +10,7 @@ function js2asr(resources, opt, cb) {
   const builder = new xml2js.Builder({
     rootName: 'resources',
     headless: false,
-    pretty: opt.pretty,
-    indent: opt.indent || ' ',
-    newline: opt.newline || '\n',
+    renderOpts: { 'pretty': opt.pretty, 'indent': opt.indent || ' ', 'newline': opt.newline || '\n' },
     xmldec: { version: '1.0', encoding: 'utf-8' }
   });
 


### PR DESCRIPTION
As stated in the README of xml2js, the render options for the xml builder have to be passed as an object instead of single options...
For more information look here: https://github.com/Leonidas-from-XIV/node-xml2js#options-for-the-builder-class